### PR TITLE
some changes

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -70,6 +70,7 @@ pub fn try_climb_step(
 
     // Only step up if horizontal motion is non zero
     if let Ok(direction) = Dir3::new(horizontal_motion) {
+        // Step up and sweep forward
         let None = spatial_query.cast_shape(
             collider,
             step_up_pos,
@@ -88,7 +89,7 @@ pub fn try_climb_step(
 
     let step_down_pos = step_up_pos + horizontal_motion;
 
-    // Sweep towards the floor
+    // Step forward and sweep down
     let (safe_distance, step_down_hit) = sweep_check(
         collider,
         epsilon,

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,112 +1,108 @@
-use bevy::prelude::*;
+use std::f32::consts::PI;
+
 use avian3d::prelude::*;
+use bevy::prelude::*;
 
 use crate::move_and_slide::*;
 
 pub const EXAMPLE_CHARACTER_RADIUS: f32 = 0.35;
-pub const EXAMPLE_CHARACTER_CAPSULE_LENGTH: f32 = 1.0; 
+pub const EXAMPLE_CHARACTER_CAPSULE_LENGTH: f32 = 1.0;
 pub const EXAMPLE_MOVEMENT_SPEED: f32 = 8.0;
 pub const EXAMPLE_GROUND_ACCELERATION: f32 = 100.0;
 pub const EXAMPLE_AIR_ACCELERATION: f32 = 40.0;
 pub const EXAMPLE_FRICTION: f32 = 60.0;
-pub const EXAMPLE_WALKABLE_ANGLE: f32 = std::f32::consts::PI / 4.0;
+pub const EXAMPLE_WALKABLE_ANGLE: f32 = PI / 4.0;
 pub const EXAMPLE_JUMP_IMPULSE: f32 = 6.0;
 pub const EXAMPLE_GRAVITY: f32 = 20.0; // realistic earth gravity tend to feel wrong for games
-pub const EXAMPLE_STEP_HEIGHT: f32 = 0.25;
+pub const EXAMPLE_STEP_HEIGHT: f32 = 1.0;
 pub const EXAMPLE_GROUND_CHECK_DISTANCE: f32 = 0.1;
 
-// @todo: probably want to improve the ergonomics of these 
-// functions by accepting a struct instead of a bunch of arguments, 
+// @todo: probably want to improve the ergonomics of these
+// functions by accepting a struct instead of a bunch of arguments,
 // that way each can be commented and we can also provide sane defaults, and ordering doesn't matter.
 
 /// Checks if a surface is walkable based on its slope angle and the up direction.
-pub fn is_walkable(hit: ShapeHitData, up: Dir3, walkable_angle: f32) -> bool {
-    let slope_angle = up.angle_between(hit.normal1);
+pub fn is_walkable(normal: Vec3, up: Dir3, walkable_angle: f32) -> bool {
+    let slope_angle = up.angle_between(normal);
     slope_angle < walkable_angle
 }
 
-/// Result of trying to climb a step.
-pub struct TryClimbStepResult {
-    pub new_translation: Vec3,
-    pub new_normal: Vec3,
-}
-
 /// Find and climb steps in the movement direction.
-/// 
+///
 /// # Prerequisites
 /// Before calling this function, it is recommended that:
 /// - The character is grounded
 /// - The character is hitting a wall
-/// 
+///
 /// # How This Works
-/// 
+///
 /// The step climbing process follows these steps:
-/// 
+///
 /// 1. **Step Height Check**
 ///    - Perform a shape-cast from the character's position
 ///    - Cast is done above ground level by the step height
 ///    - Cast is in the direction of movement
 ///    - If nothing is hit, the wall is "step-uppable"
-/// 
+///
 /// 2. **Height Discovery**
 ///    - If the above shape-cast hits nothing:
 ///      - Perform a downward shape-cast from the step up height
 ///        at the intended step up position based on the remaining motion.
 ///     - This determines the actual height of the step
-/// 
+///
 /// 3. **Step Execution**
 ///    - Teleport up by the discovered height
 ///    - Move forward with remaining motion
 pub fn try_climb_step(
+    spatial_query: &SpatialQuery,
     collider: &Collider,
-    config: &MoveAndSlideConfig,
     translation: Vec3,
     motion: Vec3,
     rotation: Quat,
-    spatial_query: &SpatialQuery,
+    up: Dir3,
     step_up_height: f32,
-    ground_check_distance: f32,
+    epsilon: f32,
     filter: &SpatialQueryFilter,
-) -> Option<TryClimbStepResult> {
-    
-    let step_up_pos = translation + Vec3::Y * (step_up_height + ground_check_distance);
+) -> Option<(Vec3, ShapeHitData)> {
+    let step_up_pos = translation + up * step_up_height;
 
-    let step_up_hit = sweep_check(
-        collider,
-        config.epsilon,
-        step_up_pos,
-        Dir3::new(motion).unwrap_or(Dir3::Z),
-        motion.length(),
-        rotation,
-        spatial_query,
-        filter,
-    );
-    
-    // We hit something at the step height, so we can't climb it.
-    if step_up_hit.is_some() {
-        return None;
+    let horizontal_motion = motion.reject_from_normalized(Vec3::Y);
+
+    // Only step up if horizontal motion is non zero
+    if let Ok(direction) = Dir3::new(horizontal_motion) {
+        let None = spatial_query.cast_shape(
+            collider,
+            step_up_pos,
+            rotation,
+            direction,
+            &ShapeCastConfig {
+                max_distance: horizontal_motion.length(),
+                ..Default::default()
+            },
+            filter,
+        ) else {
+            // We hit something at the step height, so we can't climb it.
+            return None;
+        };
     }
 
-    let step_down_pos = step_up_pos + motion;
-    let step_down_hit = sweep_check(
+    let step_down_pos = step_up_pos + horizontal_motion;
+
+    // Sweep towards the floor
+    let (safe_distance, step_down_hit) = sweep_check(
         collider,
-        config.epsilon,
+        epsilon,
         step_down_pos,
-        Dir3::NEG_Y,
-        step_up_height + ground_check_distance,
+        -up,
+        step_up_height,
         rotation,
         spatial_query,
         filter,
-    );
+    )?;
 
-    if let Some((hit_distance, hit)) = step_down_hit {        
-        Some(TryClimbStepResult {
-            new_translation: step_up_pos + motion + Dir3::NEG_Y * hit_distance,
-            new_normal: hit.normal1,
-        })
-    } else {
-        None
-    }
+    let new_translation = step_down_pos - up * safe_distance;
+
+    Some((new_translation, step_down_hit))
 }
 
 /// Check if the character is grounded and update ground state accordingly
@@ -122,8 +118,8 @@ pub fn ground_check(
     filter: &SpatialQueryFilter,
     ground_check_distance: f32,
     walkable_angle: f32,
-) -> Option<(f32, Vec3)> {
-    if let Some((movement, hit)) = sweep_check(
+) -> Option<(f32, ShapeHitData)> {
+    let (safe_distance, hit) = sweep_check(
         collider,
         config.epsilon,
         translation,
@@ -132,13 +128,11 @@ pub fn ground_check(
         rotation,
         spatial_query,
         filter,
-    ) {
-        if is_walkable(hit, up, walkable_angle) {
-            Some((movement, hit.normal1))
-        } else {
-            None
-        }
-    } else {
-        None
+    )?;
+
+    if !is_walkable(hit.normal1, up, walkable_angle) {
+        return None;
     }
+
+    Some((safe_distance, hit))
 }

--- a/src/character.rs
+++ b/src/character.rs
@@ -14,7 +14,7 @@ pub const EXAMPLE_FRICTION: f32 = 60.0;
 pub const EXAMPLE_WALKABLE_ANGLE: f32 = PI / 4.0;
 pub const EXAMPLE_JUMP_IMPULSE: f32 = 6.0;
 pub const EXAMPLE_GRAVITY: f32 = 20.0; // realistic earth gravity tend to feel wrong for games
-pub const EXAMPLE_STEP_HEIGHT: f32 = 1.0;
+pub const EXAMPLE_STEP_HEIGHT: f32 = 0.25;
 pub const EXAMPLE_GROUND_CHECK_DISTANCE: f32 = 0.1;
 
 // @todo: probably want to improve the ergonomics of these

--- a/src/move_and_slide.rs
+++ b/src/move_and_slide.rs
@@ -142,8 +142,6 @@ pub fn move_and_slide(
             continue;
         }
 
-        // It is possible the user has set the normal to None,
-        // in which case we don't want to slide along it anymore.
         hits.push(hit.normal1);
 
         velocity = solve_collision_planes(velocity, &hits, *original_direction);

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -1,3 +1,5 @@
+use std::f32::consts::PI;
+
 use avian3d::prelude::{
     Collider, CollisionLayers, RigidBody, Sensor, SpatialQuery, SpatialQueryFilter,
 };
@@ -166,7 +168,7 @@ fn movement(
                 let min_inward_distance = EXAMPLE_CHARACTER_RADIUS * a;
 
                 // Step into the hit normal alil bit
-                let inward = min_inward_distance + config.epsilon;
+                let inward = min_inward_distance + config.epsilon * PI;
 
                 // Step a lil bit less forward to account for stepping into the hit normal
                 let forward = (movement.remaining_motion - inward).max(0.0);

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -143,7 +143,7 @@ fn movement(
                 );
 
                 if walkable {
-                    // If Dir3::new can't return Err since we have already checked if it's walkable
+                    // Dir3::new won't be Err since we have already checked if it's walkable
                     new_ground = Some(Dir3::new(movement.hit_data.normal1).unwrap());
                 }
 

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -5,7 +5,10 @@ use bevy::prelude::*;
 use bevy_enhanced_input::prelude::{ActionState, Actions};
 
 use crate::{
-    camera::MainCamera, character::*, input::{self, DefaultContext, Jump}, move_and_slide::*
+    camera::MainCamera,
+    character::*,
+    input::{self, DefaultContext, Jump},
+    move_and_slide::*,
 };
 
 // @todo: we should probably move all of this into an example file, then make the project a lib instead of a bin.
@@ -64,9 +67,11 @@ fn movement(
     let main_camera_transform = main_camera.into_inner();
     for (entity, actions, mut transform, mut character, character_collider, layers) in &mut q_kcc {
         if actions.action::<Jump>().state() == ActionState::Fired {
-            if character.ground.is_some() {
-                character.velocity.y = EXAMPLE_JUMP_IMPULSE;
-                character.ground = None;
+            if character.ground.take().is_some() {
+                // Override downard velocity
+                let down_vel = character.velocity.dot(*character.up).min(0.0);
+                let jump_impulse = character.up * (EXAMPLE_JUMP_IMPULSE - down_vel);
+                character.velocity += jump_impulse;
             }
         }
 
@@ -78,29 +83,18 @@ fn movement(
         let yaw_rotation = Quat::from_rotation_y(camera_yaw);
 
         // Rotate the movement direction vector by only the camera's yaw
-        let mut direction = yaw_rotation * Vec3::new(input_vec.x, 0.0, -input_vec.y);
+        let direction = yaw_rotation * Vec3::new(input_vec.x, 0.0, -input_vec.y);
 
         let max_acceleration = match character.ground {
-            Some(floor_normal) => {
+            Some(_) => {
                 let friction = friction(character.velocity, EXAMPLE_FRICTION, time.delta_secs());
                 character.velocity += friction;
-
-                // // Make sure velocity is never towards the floor since this makes the jump height inconsistent
-                // let downward_vel = character.velocity.dot(*floor_normal).min(0.0);
-                // character.velocity -= floor_normal * downward_vel;
-
-                // Project input direction on the floor normal to allow walking down slopes
-                // TODO: this is wrong, walking diagonally up/down slopes will be slightly off direction wise,
-                // even more so for steep slopes.
-                // direction = direction
-                //     .reject_from_normalized(*floor_normal)
-                //     .normalize_or_zero();
 
                 EXAMPLE_GROUND_ACCELERATION
             }
             None => {
                 // Apply gravity when not grounded
-                let gravity = Vec3::Y * -EXAMPLE_GRAVITY * time.delta_secs();
+                let gravity = character.up * -EXAMPLE_GRAVITY * time.delta_secs();
                 character.velocity += gravity;
 
                 EXAMPLE_AIR_ACCELERATION
@@ -128,14 +122,9 @@ fn movement(
         filter.excluded_entities.extend(sensors);
 
         let config = MoveAndSlideConfig::default();
-        
-        // See notes below about why we use a cylinder collider in some stages.
-        let cylinder_collider = Collider::cylinder(
-            EXAMPLE_CHARACTER_RADIUS,
-            // need to add both radii to length to account for the capsule's hemispheres on both ends
-            // because the goal is to have the cylinder collider be the same height as the capsule collider
-            EXAMPLE_CHARACTER_CAPSULE_LENGTH + (2.0 * EXAMPLE_CHARACTER_RADIUS)
-        );
+
+        // We need to store the new ground for the ground check to work properly
+        let mut new_ground = None;
 
         if let Some(move_and_slide_result) = move_and_slide(
             &spatial_query,
@@ -146,91 +135,102 @@ fn movement(
             config,
             &filter,
             time.delta_secs(),
-            |hit| {
-                let walkable = is_walkable(hit.shape_hit, Dir3::Y, EXAMPLE_WALKABLE_ANGLE);
+            |movement| {
+                let walkable = is_walkable(
+                    movement.hit_data.normal1,
+                    character.up,
+                    EXAMPLE_WALKABLE_ANGLE,
+                );
 
-                if walkable && character.velocity.y <= 0.0 {
-                    character.ground = Some(Dir3::new(hit.shape_hit.normal1).unwrap_or(Dir3::Y));
+                if walkable {
+                    // If Dir3::new can't return Err since we have already checked if it's walkable
+                    new_ground = Some(Dir3::new(movement.hit_data.normal1).unwrap());
                 }
+
+                let grounded = character.ground.is_some() || new_ground.is_some();
 
                 // In order to try step up we need to be grounded and hitting a "wall".
-                if !walkable && character.ground.is_some() {
-
-                    if let Some(try_climb_step_result) = try_climb_step(
-                        // We use a cylinder collider for climbing up steps
-                        // because it helps climb them even at low speeds.
-                        &cylinder_collider,
-                        &config,
-                        *hit.overridable_translation,
-                        hit.remaining_motion,
-                        rotation,
-                        &spatial_query,
-                        EXAMPLE_STEP_HEIGHT,
-                        EXAMPLE_GROUND_CHECK_DISTANCE,
-                        &filter,
-                    ) {
-                        // Since we're a capsule, we need to zero out the Y velocity when 
-                        // we climb a step or it will feel like we're launching over the step.
-                        // This is because of the roundness of the capsule naturally pushing 
-                        // us up as we encroach on the step, especially at high speeds.
-                        hit.overridable_velocity.y = 0.0;
-
-                        // We need to override the translation here because the we stepped up
-                        *hit.overridable_translation = try_climb_step_result.new_translation;
-
-                        // We also need to override the normal here because the we stepped up
-                        // this is so that the sliding functionality slides along the step and 
-                        // not the wall of the step.
-                        *hit.overridable_normal = Some(try_climb_step_result.new_normal);
-
-                        if let Some((movement, hit_normal)) = ground_check(
-                            &cylinder_collider,
-                            &config,
-                            transform.translation,
-                            Dir3::Y,
-                            rotation,
-                            &spatial_query,
-                            &filter,
-                            EXAMPLE_GROUND_CHECK_DISTANCE,
-                            EXAMPLE_WALKABLE_ANGLE,
-                        ) {
-                            *hit.overridable_translation -= movement * Vec3::Y;
-                            *hit.overridable_normal = Some(hit_normal);
-                            character.ground = Some(Dir3::new(hit_normal).unwrap_or(Dir3::Y));
-                        }
-                        else {
-                            character.ground = None;
-                        }
-                    }
+                if walkable || !grounded {
+                    return true;
                 }
+
+                let horizontal_normal = movement
+                    .hit_data
+                    .normal1
+                    .reject_from_normalized(*character.up)
+                    .normalize_or_zero();
+
+                // This is necessary for capsule colliders since the normal angle changes depending on
+                // how far out on a ledge the character is standing
+                let a = 1.0 - EXAMPLE_WALKABLE_ANGLE.cos();
+                let min_inward_distance = EXAMPLE_CHARACTER_RADIUS * a;
+
+                // Step into the hit normal alil bit
+                let inward = min_inward_distance + config.epsilon;
+
+                // Step a lil bit less forward to account for stepping into the hit normal
+                let forward = (movement.remaining_motion - inward).max(0.0);
+
+                let step_motion = movement.direction * forward - horizontal_normal * inward;
+
+                let Some((step_offset, step_hit)) = try_climb_step(
+                    &spatial_query,
+                    &character_collider,
+                    *movement.translation,
+                    step_motion,
+                    rotation,
+                    character.up,
+                    EXAMPLE_STEP_HEIGHT + EXAMPLE_GROUND_CHECK_DISTANCE,
+                    config.epsilon,
+                    &filter,
+                ) else {
+                    // Can't stand here, slide instead
+                    return true;
+                };
+
+                if !is_walkable(step_hit.normal1, character.up, EXAMPLE_WALKABLE_ANGLE) {
+                    return true;
+                }
+
+                // Make sure velocity is not upwards after stepping
+                let up_vel = movement.translation.dot(*character.up).max(0.0);
+                *movement.velocity -= character.up * up_vel;
+
+                // We need to override the translation here because the we stepped up
+                *movement.translation = step_offset;
+
+                new_ground = Some(Dir3::new(step_hit.normal1).unwrap());
+
+                // Subtract the stepped distance from remaining time to avoid moving further
+                let move_time = (forward + inward) * time.delta_secs();
+                *movement.remaining_time = (*movement.remaining_time - move_time).max(0.0);
+
+                // Successfully stepped, don't slide this iteration
+                false
             },
         ) {
             transform.translation = move_and_slide_result.new_translation;
             character.velocity = move_and_slide_result.new_velocity;
         }
 
-        if character.velocity.y > 0.0 {
-            character.ground = None;
-        }
-        else {
-            if let Some((movement, hit_normal)) = ground_check(
+        if character.ground.is_some() && new_ground.is_none() {
+            if let Some((movement, hit)) = ground_check(
                 &character_collider,
                 &config,
                 transform.translation,
-                Dir3::Y,
+                character.up,
                 rotation,
                 &spatial_query,
                 &filter,
                 EXAMPLE_GROUND_CHECK_DISTANCE,
                 EXAMPLE_WALKABLE_ANGLE,
             ) {
-                transform.translation -= movement * Vec3::Y;
-                character.ground = Some(Dir3::new(hit_normal).unwrap_or(Dir3::Y));
-            }
-            else {
-                character.ground = None;
+                transform.translation -= movement * character.up;
+                new_ground = Some(Dir3::new(hit.normal1).unwrap());
             }
         }
+
+        character.ground = new_ground;
     }
 }
 


### PR DESCRIPTION
I figured this would be easier than making a review.

- I replaced (I think) all instances of `Vec3::Y` with `character.up` to make sure everything works for different up directions (mario galaxy type stuff).
- I changed the stepping a bit, now it will try to step a little bit towards the hit normal gathered from the `move_and_slide` callback, this seems to have fixed the issue where the character would sometimes slide down right after stepping. 
- I changed the step collider from a cylinder to a capsule. The cylinder shape trace was returning potential step locations that a capsule actually can't stand on, this also contributed to the sliding right after stepping I think.
- And some minor fixes and refactors.

Overall, it's still not perfect but it seems to be more consistent.

~~There seems to be some merge conflicts though, not sure why~~

EDIT: it's still possible to slide down right after stepping at certain angles, ~~investigating it now~~ I just increased the bit we step towards the hit normal for now and it seems to be fixed for the most part.

Very strange issue, it might be happening because the character slide a bit down towards the hit normal even when walking on the floor. This is because of how the velocity projection is implemented in `move_and_slide` . 

If you try jumping while standing on a ramp and not moving, you'll see what I mean by velocity sliding down towards the hit normal. You might also be able to see it when walking diagonally up steep ramps.